### PR TITLE
Fix $columnName is not initialized for relation field

### DIFF
--- a/code/bulkloader/BetterBulkLoader.php
+++ b/code/bulkloader/BetterBulkLoader.php
@@ -288,6 +288,7 @@ class BetterBulkLoader extends BulkLoader {
 		if($this->isRelation($field)){
 			$relation = null;
 			$relationName = null;
+			$columnName = null;
 			//extract relationName and columnName, if present
 			if(strpos($field, '.') !== false){
 				list($relationName, $columnName) = explode('.', $field);


### PR DESCRIPTION
When $field is passed as relation object name, then split condition at line 292 misses $columName initialization
