### PR TITLE
Modified BetterBulkLoader.php - update existing but skip new records

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ $source->setFilePath("files/myfile.csv");
 
 $loader = new BetterBulkLoader("Product");
 $loader->setSource($source);
+$loader->addNewRecords = false;  // an option to skip new records
 
 $result = $loader->load();
 ```

--- a/code/bulkloader/BetterBulkLoader.php
+++ b/code/bulkloader/BetterBulkLoader.php
@@ -38,6 +38,12 @@ class BetterBulkLoader extends BulkLoader
     protected $source;
 
     /**
+     * Add new records while importing
+     * @var boolean
+     */
+    protected $addNewRecords = true;
+
+    /**
      * The default behaviour for linking relations
      * @var boolean
      */
@@ -200,6 +206,11 @@ class BetterBulkLoader extends BulkLoader
             $obj = $existing;
             $obj->update($data);
         } else {
+            // new record
+            if (!$this->addNewRecords) {
+                $results->addSkipped('New record not added');
+                return;
+            }
             $obj = $placeholder;
         }
 


### PR DESCRIPTION
The use case is where new dataobjects need to be added manually.  For example, where new products need photos, etc. and publishing delayed until a launch date.  Thanks.
