### PR TITLE
FIX Module not compatible with translatable

### DIFF
--- a/code/gridfield/GridFieldImporter_Request.php
+++ b/code/gridfield/GridFieldImporter_Request.php
@@ -124,7 +124,8 @@ class GridFieldImporter_Request extends RequestHandler
             new LiteralField('mapperfield', $mapper->forTemplate())
         );
         $form->Fields()->push(new HiddenField("BackURL", "BackURL", $this->getBackURL($request)));
-        $form->setFormAction($this->Link('import').'/'.$file->ID);
+        $action = Controller::join_links($this->Link('import'), $file->ID);
+        $form->setFormAction($action);
         $content = ArrayData::create(array(
             'File' => $file,
             'MapperForm'=> $form


### PR DESCRIPTION
Translatable modifies controller links by adding ?Locale=XX
to the URLs. Because this url was being built manually it
was generating an incorrect URL.

eg. /admin/pages/?Locale=en_NZ/10 instead of
/admin/pages/10?Locale=en_NZ